### PR TITLE
to fix lack of motionblur with rigidbodies and objects moved by const…

### DIFF
--- a/export.py
+++ b/export.py
@@ -2041,7 +2041,7 @@ def cache_motion(scene, rpass, objects=None):
                         for subframe, mesh in data_block.motion_data:
                             if(last_mesh is None):
                                 last_mesh = mesh
-                            elif len( mesh.vertices )!= len( last_mesh.vertices):
+                            elif len( mesh.vertices )!= len( last_mesh.vertices) or len(mesh.edges)!=len(last_mesh.edges) or len(mesh.polygons)!=len(last_mesh.polygons):
                                 # Deformation motion blur with changing vertexcounts is not supported.
                                 data_block.deforming = False
                             else:

--- a/export.py
+++ b/export.py
@@ -1995,7 +1995,7 @@ def cache_motion(scene, rpass, objects=None):
 
     scene.frame_set(origframe, 0)
     elapsed = time.perf_counter() - start
-    debug("debug", "...caching transformations and deformations took [%f]"%elapsed)
+    debug("warning", "...caching transformations and deformations took [%f]"%elapsed)
     
     try:
 
@@ -3117,7 +3117,7 @@ def export_hider(ri, rpass, scene, preview=False):
 
 # I hate to make rpass global but it makes things so much easier
 def write_rib(rpass, scene, ri, visible_objects=None, engine=None):
-
+    start = time.perf_counter()
     # precalculate motion blur data
     data_blocks, instances = cache_motion(scene, rpass)
     
@@ -3168,6 +3168,9 @@ def write_rib(rpass, scene, ri, visible_objects=None, engine=None):
     ri.WorldEnd()
 
     ri.FrameEnd()
+    elapsed = time.perf_counter() - start
+    debug("warning", "...write rib took [%f]"%elapsed)
+    
 
 
 def write_preview_rib(rpass, scene, ri):


### PR DESCRIPTION
…raints all transformations are bruteforce comparisons of matrices for all subframes. Also changed deformation motionblur to be a two step process for meshes with a primary screening and a secondary brute force approach. The screening can be improved in could_be_deforming and if the brute force approach get's too slow it could possibly be multithreaded.

If debugging is enabled some timing is output to help find what takes time.
