### PR TITLE
added option to flipv on rib export

### DIFF
--- a/properties.py
+++ b/properties.py
@@ -1942,6 +1942,13 @@ class RendermanMeshGeometrySettings(bpy.types.PropertyGroup):
         name="Export Default Vertex Color",
         description="Export the active Vertex Color set as the default 'Cs' primitive variable",
         default=True)
+    export_flipv = EnumProperty(
+        name="FlipV",
+        description="Use this to flip the V texture coordinate on the exported geometry when rendering. The origin on Renderman texture coordinates are top-left (ie. Photoshop) of image, UV texture coordinates (ie. Maya) generally use the bottom-left of the image as the origin. It's generally better to do this flip using a pattern like PxrTexture or PxrManifold2d",
+        items=[('NONE', 'No Flip', 'Do not do anything to the UVs.'),
+               ('TILE', 'Flip Tile Space', 'Flips V in tile space. Works with UDIM.'),
+               ('UV', 'Flip UV Space', 'Flips V in UV space. This is here for backwards compatability.')],
+        default='NONE')
     interp_boundary = IntProperty(
         name="Subdivision Edge Interpolation Mode",
         description="Defines how a subdivided mesh interpolates its boundary edges",

--- a/ui.py
+++ b/ui.py
@@ -619,6 +619,7 @@ class MESH_PT_renderman_prim_vars(CollectionPanel, Panel):
 
         layout.prop(rm, "export_default_uv")
         layout.prop(rm, "export_default_vcol")
+        layout.prop(rm, "export_flipv")
         layout.prop(rm, "interp_boundary")
         layout.prop(rm, "face_boundary")
 


### PR DESCRIPTION
Add object setting to flipV on geometry rib export.

Three modes.

1. None. Default. Don't do anything.
2. Tile. Flip within tile space. This works with UDIMs.
3. UV. Flip in UV space. This ends up putting UDIMs tiles above 1010 into negative UV space.

Recommended is 1, don't do anything. Flipping of V should be done in the pattern (PxrTexture, PxrManifold2d).
Number 2 is provided if for whatever reason you can't use a pattern due to shading network setup.
Number 3 is provided for backwards compatable with old scenes.