### PR TITLE
Closes #566

### DIFF
--- a/export.py
+++ b/export.py
@@ -2572,9 +2572,14 @@ def export_dupli_archive(ri, scene, rpass, data_block, data_blocks):
 
 # export an archive with all the materials and read it back in
 def export_materials_archive(ri, rpass, scene):
-    archive_filename = user_path(scene.renderman.path_object_archive_static,
-                                 scene).replace('{object}', 'materials')
+    if scene.renderman.external_animation:
+        _p_ = user_path(scene.renderman.path_object_archive_animated, scene)
+        archive_filename = _p_.replace('{object}', 'materials')
+    else:
+        _p_ = user_path(scene.renderman.path_object_archive_static, scene)
+        archive_filename = _p_.replace('{object}', 'materials')
     ri.Begin(archive_filename)
+
     for mat_name, mat in bpy.data.materials.items():
         ri.ArchiveBegin('material.' + get_mat_name(mat_name))
         # ri.Attribute("identifier", {"name": mat_name})

--- a/nodes.py
+++ b/nodes.py
@@ -651,7 +651,7 @@ def generate_node_type(prefs, name, args):
             node_group.use_fake_user = True
             self.node_group = node_group.name
         update_conditional_visops(self)
-        
+
 
     def free(self):
         if name == "PxrRamp":
@@ -868,7 +868,7 @@ def draw_node_properties_recursive(layout, context, nt, node, level=0):
                                     row.prop(node, pn, text='')
                                     sub_prop_names.remove(pn)
                                     break
-                        
+
                         row.label(prop_name.split('.')[-1] + ':')
 
                         if ui_open:
@@ -1428,7 +1428,7 @@ def gen_params(ri, node, mat_name=None):
                         in_sock = group_output.inputs[from_socket.name]
                         if len(in_sock.links):
                             from_socket = in_sock.links[0].from_socket
-                            temp_mat_name = mat_name + '.' + from_socket.node.name    
+                            temp_mat_name = mat_name + '.' + from_socket.node.name
 
                     vstruct_from_param = "%s_%s" % (
                         from_socket.identifier, vstruct_member)
@@ -1998,7 +1998,7 @@ def replace_frame_num(prop):
     prop = prop.replace('$f4', str(frame_num).zfill(4))
     prop = prop.replace('$F4', str(frame_num).zfill(4))
     prop = prop.replace('$f3', str(frame_num).zfill(3))
-    prop = prop.replace('$f3', str(frame_num).zfill(3))
+    prop = prop.replace('$F3', str(frame_num).zfill(3))
     return prop
 
 # return the output file name if this texture is to be txmade.
@@ -2006,9 +2006,17 @@ def replace_frame_num(prop):
 
 def get_tex_file_name(prop):
     prop = replace_frame_num(prop)
-    prop = prop.replace('\\', '\/')
-    if prop != '' and prop.rsplit('.', 1) != 'tex':
-        return os.path.basename(prop).rsplit('.', 1)[0] + '.tex'
+    prop = bpy.path.basename(prop)
+    part = prop.rpartition('.')
+    prop = part[0]
+    if prop != '' and part[2].lower() != 'tex':
+        _p_ = bpy.context.scene.renderman.path_texture_output
+        #
+        # just in case there is a leading path separator
+        #
+        _s_ = "" if _p_.endswith("/") or _p_.endswith("\\") else "/"
+        _f_ = "{}{}{}{}".format(_p_, _s_, prop, ".tex")
+        return user_path(_f_)
     else:
         return prop
 
@@ -2326,6 +2334,6 @@ def register():
 def unregister():
     nodeitems_utils.unregister_node_categories("RENDERMANSHADERNODES")
     # bpy.utils.unregister_module(__name__)
-    
+
     for cls in classes:
         bpy.utils.unregister_class(cls)

--- a/nodes.py
+++ b/nodes.py
@@ -375,7 +375,7 @@ class RendermanShadingNode(bpy.types.ShaderNode):
                     continue
                 if prop_name not in self.inputs:
                     if prop_meta['renderman_type'] == 'page':
-                        ui_prop = prop_name + "_ui_open"
+                        ui_prop = prop_name + "_uio"
                         ui_open = getattr(self, ui_prop)
                         icon = 'DISCLOSURE_TRI_DOWN' if ui_open \
                             else 'DISCLOSURE_TRI_RIGHT'
@@ -849,7 +849,7 @@ def draw_node_properties_recursive(layout, context, nt, node, level=0):
                 else:
                     row = layout.row(align=True)
                     if prop_meta['renderman_type'] == 'page':
-                        ui_prop = prop_name + "_ui_open"
+                        ui_prop = prop_name + "_uio"
                         ui_open = getattr(node, ui_prop)
                         icon = 'DISCLOSURE_TRI_DOWN' if ui_open \
                             else 'DISCLOSURE_TRI_RIGHT'

--- a/shader_parameters.py
+++ b/shader_parameters.py
@@ -77,7 +77,7 @@ def generate_page(sp, node, parent_name, first_level=False):
             prop_meta.update(sub_meta)
             prop_meta[name] = {'renderman_type': 'page'}
             prop_names.append(name)
-            ui_label = "%s_ui_open" % name
+            ui_label = "%s_uio" % name
             setattr(node, ui_label, BoolProperty(name=ui_label,
                                                  default=False))
         else:
@@ -98,13 +98,13 @@ def generate_page(sp, node, parent_name, first_level=False):
                 prop_names.append("TxMake Options")
                 prop_meta["TxMake Options"] = {'renderman_type': 'page'}
                 setattr(node, "TxMake Options", optionsNames)
-                ui_label = "%s_ui_open" % "TxMake Options"
+                ui_label = "%s_uio" % "TxMake Options"
                 setattr(node, ui_label, BoolProperty(name=ui_label,
                                                      default=False))
                 prop_meta.update(optionsMeta)
                 for Texname in optionsNames:
                     setattr(
-                        node, Texname + "_ui_open", optionsProps[Texname])
+                        node, Texname + "_uio", optionsProps[Texname])
                     setattr(node, Texname, optionsProps[Texname])
 
             # if name == sp.attrib['name']:
@@ -175,7 +175,7 @@ def class_generate_properties(node, parent_name, shaderparameters):
                 sp, node, page_name, first_level=first_level)
             prop_names.append(page_name)
             prop_meta[page_name] = {'renderman_type': 'page'}
-            ui_label = "%s_ui_open" % page_name
+            ui_label = "%s_uio" % page_name
             setattr(node, ui_label, BoolProperty(name=ui_label,
                                                  default=False))
             prop_meta.update(sub_params_meta)
@@ -204,13 +204,13 @@ def class_generate_properties(node, parent_name, shaderparameters):
                 prop_names.append("TxMake Options")
                 prop_meta["TxMake Options"] = {'renderman_type': 'page'}
                 setattr(node, "TxMake Options", optionsNames)
-                ui_label = "%s_ui_open" % "TxMake Options"
+                ui_label = "%s_uio" % "TxMake Options"
                 setattr(node, ui_label, BoolProperty(name=ui_label,
                                                      default=False))
                 prop_meta.update(optionsMeta)
                 for Texname in optionsNames:
                     setattr(
-                        node, Texname + "_ui_open", optionsProps[Texname])
+                        node, Texname + "_uio", optionsProps[Texname])
                     setattr(node, Texname, optionsProps[Texname])
 
     setattr(node, 'prop_names', prop_names)

--- a/ui.py
+++ b/ui.py
@@ -183,7 +183,7 @@ class RENDER_PT_renderman_render(PRManButtonsPanel, Panel):
         layout = self.layout
         rd = context.scene.render
         rm = context.scene.renderman
-        
+
         # Render
         row = layout.row(align=True)
         rman_render = icons.get("render")
@@ -381,7 +381,7 @@ def draw_props(node, prop_names, layout):
         row = layout.row()
 
         if prop_meta['renderman_type'] == 'page':
-            ui_prop = prop_name + "_ui_open"
+            ui_prop = prop_name + "_uio"
             ui_open = getattr(node, ui_prop)
             icon = 'DISCLOSURE_TRI_DOWN' if ui_open \
                 else 'DISCLOSURE_TRI_RIGHT'


### PR DESCRIPTION
**This fix solves three problems if animation for external render was enabled:**

- sequenced textures -- using $F3 or $F4 in the filename property -- was written everytime to the same file named `.tex`, even if the basename of the file is missing, this file gots overwritten for every frame iteration, so in reality only the last image of the sequence was used for the entire sequence
- texture generation in the folder of the blend file instead of `$OUT/textures` or any other value from preferences
- if animation was enabled the export wrote `material.rib` to `$OUT/archives/static` instead of `$OUT/archives/#####/`, so the material.rib file was only valid for last frame, because former rib files got overwritten

Tested on Windows only, but I don't expect any platform specific issues, anyway testing on linux and macOS is very welcome.
