### PR TITLE
fix asset path, fix missing cache file

### DIFF
--- a/rman_operators/rman_operators_utils.py
+++ b/rman_operators/rman_operators_utils.py
@@ -124,9 +124,21 @@ class PRMAN_OT_Renderman_Package(Operator):
             bfile = os.path.basename(openvdb_file)
             diskpath = os.path.join(assets_dir, bfile)
             shutil.copyfile(openvdb_file, diskpath)      
-            setattr(db, 'filepath', '//./assets/%s' % bfile)   
+            #setattr(db, 'filepath', '//./assets/%s' % bfile) # Arig ranch mod
+            setattr(db, 'filepath', '//assets/%s' % bfile)            
             z.write(diskpath, arcname=os.path.join('assets', bfile))               
             remove_files.append(diskpath)
+            
+        # Caches # Arig ranch mod
+        # https://docs.blender.org/manual/fr/dev/animation/constraints/transform/transform_cache.html
+        for cache in bpy.data.cache_files:
+            cache_file = filepath_utils.get_real_path(cache.filepath)
+            bfile = os.path.basename(cache_file)
+            diskpath = os.path.join(assets_dir, bfile)
+            shutil.copyfile(cache_file, diskpath)      
+            setattr(cache, 'filepath', '//assets/%s' % bfile)            
+            z.write(diskpath, arcname=os.path.join('assets', bfile))               
+            remove_files.append(diskpath)            
 
         # archives etc.
         for ob in bpy.data.objects:


### PR DESCRIPTION
Two Fixes in  PRMAN_OT_Renderman_Package:../rman_operators/rman_operators_utils.py
- Fix Asset relative Path
- Fix missing transform caches
Can be tested with the official Swatch exemple https://renderman.pixar.com/official-swatch
