### PR TITLE
Check if Blender version is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 RenderMan for Blender is a render engine addon written for the 3D creation suite [Blender](https://www.blender.org/).
 
+## Supported Blender versions
+
+RenderMan supports Blender versions up to 3.0
+
 ## Installing
 
 To use, install RenderMan, (free from [renderman.pixar.com](https://renderman.pixar.com/store/intro)), download [the latest release](https://github.com/prman-pixar/RenderManForBlender/releases) and put it in the addons folder for Blender. See the [installation.txt](installation.txt) file for detailed instructions.

--- a/preferences.py
+++ b/preferences.py
@@ -735,6 +735,13 @@ class RendermanPreferences(AddonPreferences):
         col = row.column()
         col.prop(self, 'rmantree_method')
 
+         # Check if Blender is using newer version of python than 3.9. This can be removed when renderman supports python 3.10.
+        if sys.version_info[1] > 9:
+            row = layout.row()
+            row.alert = True
+            row.label(text='This verion of Blender is not supported. We support Blender versions up to 3.0.x.', icon='ERROR')
+            return
+
         if self.rmantree_method == 'MANUAL':
             col.prop(self, "path_rmantree")
             if envconfig_utils.envconfig() is None:

--- a/preferences.py
+++ b/preferences.py
@@ -739,7 +739,7 @@ class RendermanPreferences(AddonPreferences):
         if sys.version_info[1] > 9:
             row = layout.row()
             row.alert = True
-            row.label(text='This verion of Blender is not supported. We support Blender versions up to 3.0.x.', icon='ERROR')
+            row.label(text='This version of Blender is not supported. We support Blender versions up to 3.0.x.', icon='ERROR')
             return
 
         if self.rmantree_method == 'MANUAL':


### PR DESCRIPTION
I've added a check that will display an error message about the blender version when the user tries to enable the addon in a Blender version that is using python 3.10. I've also added the supported Blender versions to the read me.
![Screenshot 2023-04-23 162412](https://user-images.githubusercontent.com/45272430/233845473-fdbcbcfc-57ec-4f9e-87f8-5883c7eda652.png)
