### PR TITLE
Fix simple shader from material display color

### DIFF
--- a/rman_translators/rman_material_translator.py
+++ b/rman_translators/rman_material_translator.py
@@ -295,8 +295,11 @@ class RmanMaterialTranslator(RmanTranslator):
         bxdf_name = '%s_PxrDisneyBsdf' % name
         sg_node = self.rman_scene.rman.SGManager.RixSGShader("Bxdf", "PxrDisneyBsdf", bxdf_name)
         rix_params = sg_node.params
+        # use the material's Viewport Display properties
         diffuse_color = string_utils.convert_val(mat.diffuse_color, type_hint='color')
-        rix_params.SetColor('baseColor', diffuse_color)
+        # color is RGBA, so assign alpha separately
+        rix_params.SetColor('baseColor', diffuse_color[:3])
+        rix_params.SetFloat('presence', diffuse_color[3])
         rix_params.SetFloat('metallic', mat.metallic )
         rix_params.SetFloat('roughness', mat.roughness)
         rix_params.SetFloat('specReflectScale', mat.metallic )


### PR DESCRIPTION
This exception was popping up as I was looking into why I wasn't able to start IPR. It was not the problem stopping IPR but seems like there's a bug anyways. As far back as I have Blender versions on my computer, the diffuse color option in the material's properties is RGBA, but SetColor only takes max 3 values. The alpha should be copied in the shader's presence.